### PR TITLE
Add support for long-range dispersion correction, Beutler soft-core, and LambdaSchedule.reverse()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Changelog
 
 * Add support for getting and restoring sampling statistics.
 * Handle XED force field virtual sites.
+* Add support for long-range Lennard-Jones dispersion correction.
+* Add support for Beutler soft-core Lennard-Jones form.
 
 [2025.2.0](https://github.com/openbiosim/loch/compare/2025.1.0...2025.2.0) - Feb 2026
 -------------------------------------------------------------------------------------

--- a/src/loch/_kernels.py
+++ b/src/loch/_kernels.py
@@ -395,10 +395,10 @@ code = """
             float rf_kappa,
             float rf_correction,
             int softcore_form,
-            float sc_coulomb_power,
             float sc_shift_coulomb,
             float sc_shift_delta,
-            int sc_taylor_power)
+            int sc_taylor_power,
+            float sc_beutler_alpha)
         {
             // Work out the atom index.
             const int idx_atom = GET_GLOBAL_ID(0);
@@ -562,6 +562,7 @@ code = """
 
                                 // Compute the LJ interaction using the chosen soft-core form.
                                 float sig6;
+                                float lj_prefactor = 1.0f;
                                 if (softcore_form == 1)
                                 {
                                     // Taylor soft-core LJ:
@@ -573,6 +574,16 @@ code = """
                                         : powf(a, (float)sc_taylor_power);
                                     sig6 = s6_val / (alpha_m * s6_val + r6);
                                 }
+                                else if (softcore_form == 2)
+                                {
+                                    // Beutler soft-core LJ:
+                                    //   sig6 = sigma^6 / (sc_beutler_alpha * sigma^6 * alpha + r^6)
+                                    //   V_LJ = (1 - alpha) * 4 * epsilon * sig6 * (sig6 - 1)
+                                    const float s6_val = powf(s, 6.0f);
+                                    const float r6 = r * r * r * r * r * r;
+                                    sig6 = s6_val / (sc_beutler_alpha * s6_val * a + r6);
+                                    lj_prefactor = 1.0f - a;
+                                }
                                 else
                                 {
                                     // Zacharias soft-core LJ:
@@ -581,22 +592,11 @@ code = """
                                     const float delta_lj = sc_shift_delta * a;
                                     sig6 = powf(s, 6.0f) / powf((s * delta_lj) + (r * r), 3.0f);
                                 }
-                                energy_lj[idx] += 4.0f * e * sig6 * (sig6 - 1.0f);
-
-                                // Compute the Coulomb power expression.
-                                float cpe;
-                                if (sc_coulomb_power == 0.0f)
-                                {
-                                    cpe = 1.0f;
-                                }
-                                else
-                                {
-                                    cpe = powf((1.0f - a), sc_coulomb_power);
-                                }
+                                energy_lj[idx] += lj_prefactor * 4.0f * e * sig6 * (sig6 - 1.0f);
 
                                 // Compute the Coulomb interaction.
                                 energy_coul[idx] += (q0 * q1) *
-                                    ((cpe / sqrtf((sc_shift_coulomb * sc_shift_coulomb * a)
+                                    ((1.0f / sqrtf((sc_shift_coulomb * sc_shift_coulomb * a)
                                     + (r * r))) + (rf_kappa * r2) - rf_correction);
 
                             }

--- a/src/loch/_kernels.py
+++ b/src/loch/_kernels.py
@@ -551,14 +551,13 @@ code = """
                                 const float e = sqrtf(e0 * e1);
                                 const float a = alpha[idx_atom];
 
-                                // Compute the distance between the atoms.
-                                float r = sqrtf(r2);
+                                // Clamp r2 to avoid singularities.
+                                const float r2_sc = (r2 < 1e-6f) ? 1e-6f : r2;
 
-                                // Truncate the distance.
-                                if (r < 0.001f)
-                                {
-                                    r = 0.001f;
-                                }
+                                // Precompute r^6 and sigma^6 using r2 directly (avoids sqrtf and powf).
+                                const float r6 = r2_sc * r2_sc * r2_sc;
+                                const float s2 = s * s;
+                                const float s6_val = s2 * s2 * s2;
 
                                 // Compute the LJ interaction using the chosen soft-core form.
                                 float sig6;
@@ -567,8 +566,6 @@ code = """
                                 {
                                     // Taylor soft-core LJ:
                                     //   sig6 = sigma^6 / (alpha^m * sigma^6 + r^6)
-                                    const float s6_val = powf(s, 6.0f);
-                                    const float r6 = r * r * r * r * r * r;
                                     const float alpha_m = (sc_taylor_power == 1) ? a
                                         : (sc_taylor_power == 0) ? 1.0f
                                         : powf(a, (float)sc_taylor_power);
@@ -579,8 +576,6 @@ code = """
                                     // Beutler soft-core LJ:
                                     //   sig6 = sigma^6 / (sc_beutler_alpha * sigma^6 * alpha + r^6)
                                     //   V_LJ = (1 - alpha) * 4 * epsilon * sig6 * (sig6 - 1)
-                                    const float s6_val = powf(s, 6.0f);
-                                    const float r6 = r * r * r * r * r * r;
                                     sig6 = s6_val / (sc_beutler_alpha * s6_val * a + r6);
                                     lj_prefactor = 1.0f - a;
                                 }
@@ -590,14 +585,15 @@ code = """
                                     //   sig6 = sigma^6 / (sigma*delta + r^2)^3
                                     //   delta = shift_delta * alpha
                                     const float delta_lj = sc_shift_delta * a;
-                                    sig6 = powf(s, 6.0f) / powf((s * delta_lj) + (r * r), 3.0f);
+                                    const float denom = (s * delta_lj) + r2_sc;
+                                    sig6 = s6_val / (denom * denom * denom);
                                 }
                                 energy_lj[idx] += lj_prefactor * 4.0f * e * sig6 * (sig6 - 1.0f);
 
                                 // Compute the Coulomb interaction.
                                 energy_coul[idx] += (q0 * q1) *
                                     ((1.0f / sqrtf((sc_shift_coulomb * sc_shift_coulomb * a)
-                                    + (r * r))) + (rf_kappa * r2) - rf_correction);
+                                    + r2_sc)) + (rf_kappa * r2) - rf_correction);
 
                             }
                         }

--- a/src/loch/_sampler.py
+++ b/src/loch/_sampler.py
@@ -287,6 +287,11 @@ class GCMCSampler:
         else:
             self._is_pme = False
 
+        # LRC state: initialised lazily on first move() call.
+        self._has_gcmc_lrc = False
+        self._lrc_w_solute = 0.0
+        self._lrc_ww_half = 0.0
+
         try:
             self._radius = self._validate_sire_unit("radius", radius, _sr.u("A"))
         except Exception as e:
@@ -707,7 +712,8 @@ class GCMCSampler:
 
         # Null the nonbonded forces.
         self._nonbonded_force = None
-        self._custom_nonbonded_force = None
+        self._custom_coulomb_force = None
+        self._custom_lj_force = None
 
         # Flag for whether the last move was a bulk sampling move.
         self._is_bulk = False
@@ -1148,7 +1154,8 @@ class GCMCSampler:
 
         # Clear the forces.
         self._nonbonded_force = None
-        self._custom_nonbonded_force = None
+        self._custom_coulomb_force = None
+        self._custom_lj_force = None
 
         # Clear the OpenMM context.
         self._openmm_context = None
@@ -1273,6 +1280,10 @@ class GCMCSampler:
                 # We only need to get the positions and initial energy for the first
                 # batch. These will be updated dynamically as moves are accepted.
                 if num_batches == 1:
+                    # Detect GCMC LRC parameters from context on first call.
+                    if not self._has_gcmc_lrc:
+                        self._init_gcmc_lrc(context)
+
                     # Get the OpenMM state.
                     state = context.getState(getPositions=True, getEnergy=self._is_pme)
 
@@ -1285,6 +1296,11 @@ class GCMCSampler:
                         initial_energy = state.getPotentialEnergy()
                     else:
                         initial_energy = None
+
+                    # Cache the box volume (NVT, so constant throughout).
+                    if self._has_gcmc_lrc:
+                        box = state.getPeriodicBoxVectors(asNumpy=True)
+                        v_nm3 = _np.linalg.det(box / _openmm.unit.nanometer)
 
                     # Sample within the GCMC sphere.
                     if self._reference is not None and not self._is_bulk:
@@ -1521,6 +1537,10 @@ class GCMCSampler:
 
                 # Insertion move.
                 if is_deletion[idx] == 0:
+                    # Capture n_w before the insertion for LRC delta calculation.
+                    if self._has_gcmc_lrc:
+                        n_w_before_insert = context.getParameter("n_w")
+
                     # Accept the move.
                     self._accept_insertion(
                         idx, idx_water, positions_openmm, positions_angstrom, context
@@ -1547,6 +1567,19 @@ class GCMCSampler:
                         final_energy = context.getState(
                             getEnergy=True
                         ).getPotentialEnergy()
+
+                        # Add the analytic LRC delta so the PME correction sees only
+                        # the RF→PME electrostatic difference.
+                        if self._has_gcmc_lrc:
+                            dLRC = (
+                                (
+                                    self._lrc_w_solute
+                                    + 2.0 * n_w_before_insert * self._lrc_ww_half
+                                )
+                                / v_nm3
+                                * _openmm.unit.kilojoules_per_mole
+                            )
+                            dE_RF += dLRC
 
                         # Compute the PME acceptance correction.
                         acc_prob = _np.exp(
@@ -1608,6 +1641,10 @@ class GCMCSampler:
 
                 # Deletion move.
                 else:
+                    # Capture n_w before the deletion for LRC delta calculation.
+                    if self._has_gcmc_lrc:
+                        n_w_before_delete = context.getParameter("n_w")
+
                     # Accept the move.
                     self._accept_deletion(candidates[idx], context)
 
@@ -1632,6 +1669,20 @@ class GCMCSampler:
                         final_energy = context.getState(
                             getEnergy=True
                         ).getPotentialEnergy()
+
+                        # Add the analytic LRC delta.
+                        if self._has_gcmc_lrc:
+                            dLRC = (
+                                -(
+                                    self._lrc_w_solute
+                                    + 2.0
+                                    * (n_w_before_delete - 1.0)
+                                    * self._lrc_ww_half
+                                )
+                                / v_nm3
+                                * _openmm.unit.kilojoules_per_mole
+                            )
+                            dE_RF += dLRC
 
                         # Compute the PME acceptance correction.
                         acc_prob = _np.exp(
@@ -2125,31 +2176,37 @@ class GCMCSampler:
             )
 
             # Flags for the required force.
-            has_gng = False
+            has_gng_coul = False
+            has_gng_lj = False
 
             # Find the required forces.
             for force in d.context().getSystem().getForces():
-                if force.getName() == "GhostNonGhostNonbondedForce":
-                    gng_force = force
-                    has_gng = True
-                    break
+                if force.getName() == "GhostNonGhostCoulombForce":
+                    gng_coul_force = force
+                    has_gng_coul = True
+                elif force.getName() == "GhostNonGhostLJForce":
+                    gng_lj_force = force
+                    has_gng_lj = True
 
             # Make sure the force was found.
-            if not has_gng:
+            if not has_gng_coul:
                 raise ValueError(
-                    "Could not find the GhostNonGhostNonbondedForce in the system"
+                    "Could not find the GhostNonGhostCoulombForce in the system"
+                )
+            if not has_gng_lj:
+                raise ValueError(
+                    "Could not find the GhostNonGhostLJForce in the system"
                 )
 
-            # Get the parameters for the GhostNonGhostNonbondedForce.
+            # Get the parameters for the GhostNonGhost nonbonded forces.
             charges = _np.zeros(self._num_atoms, dtype=_np.float32)
             sigmas = _np.zeros(self._num_atoms, dtype=_np.float32)
             epsilons = _np.zeros(self._num_atoms, dtype=_np.float32)
             alphas = _np.zeros(self._num_atoms, dtype=_np.float32)
-            for i in range(gng_force.getNumParticles()):
+            for i in range(gng_coul_force.getNumParticles()):
                 # Custom force parameters are returned as floats.
-                q, half_sigma, two_sqrt_epsilon, alpha, _ = (
-                    gng_force.getParticleParameters(i)
-                )
+                q, alpha, _ = gng_coul_force.getParticleParameters(i)
+                half_sigma, two_sqrt_epsilon, _ = gng_lj_force.getParticleParameters(i)
                 # Charge in |e|, sigma in nm, epsilon in kJ/mol.
                 charges[i] = q
                 # Rescale and convert units.
@@ -2321,6 +2378,15 @@ class GCMCSampler:
             (1, self._num_waters), _np.int32
         )
 
+    def _init_gcmc_lrc(self, context):
+        """Detect and cache GCMC LRC parameters from the OpenMM context."""
+        try:
+            self._lrc_w_solute = context.getParameter("lrc_w_solute")
+            self._lrc_ww_half = context.getParameter("lrc_ww_half")
+            self._has_gcmc_lrc = True
+        except Exception:
+            self._has_gcmc_lrc = False
+
     def _accept_insertion(
         self, idx, idx_water, positions_openmm, positions_angstrom, context
     ):
@@ -2374,13 +2440,19 @@ class GCMCSampler:
             )
             # Update the custom NonBondedForce parameters.
             if self._is_fep:
-                self._custom_nonbonded_force.setParticleParameters(
+                self._custom_coulomb_force.setParticleParameters(
                     start_idx + i,
                     (
                         self._water_charge[i],
+                        0.0,
+                        0.0,
+                    ),
+                )
+                self._custom_lj_force.setParticleParameters(
+                    start_idx + i,
+                    (
                         self._water_sigma_custom[i],
                         self._water_epsilon_custom[i],
-                        0.0,
                         0.0,
                     ),
                 )
@@ -2393,7 +2465,8 @@ class GCMCSampler:
 
         # Update the CustomNonbondedForce parameters in the context.
         if self._is_fep:
-            self._custom_nonbonded_force.updateParametersInContext(context)
+            self._custom_coulomb_force.updateParametersInContext(context)
+            self._custom_lj_force.updateParametersInContext(context)
 
         # Update the state of the water on the GPU.
         self._kernels["update_water"](
@@ -2416,6 +2489,10 @@ class GCMCSampler:
 
         # Update the number of waters in the sampling volume.
         self._N += 1
+
+        # Update the GCMC LRC water count in the context.
+        if self._has_gcmc_lrc:
+            context.setParameter("n_w", context.getParameter("n_w") + 1.0)
 
     def _accept_deletion(self, idx, context):
         """
@@ -2445,12 +2522,18 @@ class GCMCSampler:
             )
             # Update the CustomNonBondedForce parameters.
             if self._is_fep:
-                self._custom_nonbonded_force.setParticleParameters(
+                self._custom_coulomb_force.setParticleParameters(
                     start_idx + i,
                     (
                         0.0,
-                        self._water_sigma_custom[i],
                         0.0,
+                        0.0,
+                    ),
+                )
+                self._custom_lj_force.setParticleParameters(
+                    start_idx + i,
+                    (
+                        self._water_sigma_custom[i],
                         0.0,
                         0.0,
                     ),
@@ -2461,7 +2544,8 @@ class GCMCSampler:
 
         # Update the CustomNonbondedForce parameters in the context.
         if self._is_fep:
-            self._custom_nonbonded_force.updateParametersInContext(context)
+            self._custom_coulomb_force.updateParametersInContext(context)
+            self._custom_lj_force.updateParametersInContext(context)
 
         # Update the state of the water on the GPU.
         self._kernels["update_water"](
@@ -2486,6 +2570,10 @@ class GCMCSampler:
 
         # Update the number of waters in the sampling volume.
         self._N -= 1
+
+        # Update the GCMC LRC water count in the context.
+        if self._has_gcmc_lrc:
+            context.setParameter("n_w", context.getParameter("n_w") - 1.0)
 
     def _reject_deletion(self, idx, context):
         """
@@ -2518,13 +2606,19 @@ class GCMCSampler:
             )
             # Update the CustomNonBondedForce parameters.
             if self._is_fep:
-                self._custom_nonbonded_force.setParticleParameters(
+                self._custom_coulomb_force.setParticleParameters(
                     start_idx + i,
                     (
                         self._water_charge[i],
+                        0.0,
+                        0.0,
+                    ),
+                )
+                self._custom_lj_force.setParticleParameters(
+                    start_idx + i,
+                    (
                         self._water_sigma_custom[i],
                         self._water_epsilon_custom[i],
-                        0.0,
                         0.0,
                     ),
                 )
@@ -2534,7 +2628,8 @@ class GCMCSampler:
 
         # Update the CustomNonbondedForce parameters in the context.
         if self._is_fep:
-            self._custom_nonbonded_force.updateParametersInContext(context)
+            self._custom_coulomb_force.updateParametersInContext(context)
+            self._custom_lj_force.updateParametersInContext(context)
 
         # Update the state of the water on the GPU.
         self._kernels["update_water"](
@@ -2559,6 +2654,10 @@ class GCMCSampler:
 
         # Update the number of waters in the sampling volume.
         self._N += 1
+
+        # Update the GCMC LRC water count in the context.
+        if self._has_gcmc_lrc:
+            context.setParameter("n_w", context.getParameter("n_w") + 1.0)
 
     def _set_water_state(self, context, indices=None, states=None, force=False):
         """
@@ -2597,7 +2696,8 @@ class GCMCSampler:
             # Assume the context has been recreated, so we need to get the
             # new forces.
             self._nonbonded_force = None
-            self._custom_nonbonded_force = None
+            self._custom_coulomb_force = None
+            self._custom_lj_force = None
             # Update even if the state is unchanged.
             force = True
 
@@ -2627,12 +2727,18 @@ class GCMCSampler:
                     )
                     # Update the CustomNonbondedForce parameters.
                     if self._is_fep:
-                        self._custom_nonbonded_force.setParticleParameters(
+                        self._custom_coulomb_force.setParticleParameters(
                             start_idx + i,
                             (
                                 0.0,
-                                self._water_sigma_custom[i],
                                 0.0,
+                                0.0,
+                            ),
+                        )
+                        self._custom_lj_force.setParticleParameters(
+                            start_idx + i,
+                            (
+                                self._water_sigma_custom[i],
                                 0.0,
                                 0.0,
                             ),
@@ -2674,13 +2780,19 @@ class GCMCSampler:
                     )
                     # Update the CustomNonBondedForce parameters.
                     if self._is_fep:
-                        self._custom_nonbonded_force.setParticleParameters(
+                        self._custom_coulomb_force.setParticleParameters(
                             start_idx + i,
                             (
                                 self._water_charge[i],
+                                0.0,
+                                0.0,
+                            ),
+                        )
+                        self._custom_lj_force.setParticleParameters(
+                            start_idx + i,
+                            (
                                 self._water_sigma_custom[i],
                                 self._water_epsilon_custom[i],
-                                0.0,
                                 0.0,
                             ),
                         )
@@ -2717,7 +2829,8 @@ class GCMCSampler:
 
         # Update the CustomNonbondedForce parameters in the context.
         if self._is_fep:
-            self._custom_nonbonded_force.updateParametersInContext(context)
+            self._custom_coulomb_force.updateParametersInContext(context)
+            self._custom_lj_force.updateParametersInContext(context)
 
     def _set_nonbonded_forces(self, context):
         """
@@ -2730,13 +2843,15 @@ class GCMCSampler:
             The OpenMM context to use.
         """
         if self._nonbonded_force is None or (
-            self._is_fep and self._custom_nonbonded_force is None
+            self._is_fep and self._custom_coulomb_force is None
         ):
             for force in context.getSystem().getForces():
                 if isinstance(force, _openmm.NonbondedForce):
                     self._nonbonded_force = force
-                elif self._is_fep and force.getName() == "GhostNonGhostNonbondedForce":
-                    self._custom_nonbonded_force = force
+                elif self._is_fep and force.getName() == "GhostNonGhostCoulombForce":
+                    self._custom_coulomb_force = force
+                elif self._is_fep and force.getName() == "GhostNonGhostLJForce":
+                    self._custom_lj_force = force
                 elif "Barostat" in force.getName():
                     msg = (
                         f"GCMC must be used at constant volume: "
@@ -2750,7 +2865,9 @@ class GCMCSampler:
             _logger.error(msg)
             raise ValueError(msg)
 
-        if self._is_fep and self._custom_nonbonded_force is None:
+        if self._is_fep and (
+            self._custom_coulomb_force is None or self._custom_lj_force is None
+        ):
             msg = "Could not find a CustomNonbondedForce in the system"
             _logger.error(msg)
             raise ValueError(msg)

--- a/src/loch/_sampler.py
+++ b/src/loch/_sampler.py
@@ -719,8 +719,7 @@ class GCMCSampler:
 
         # Null the nonbonded forces.
         self._nonbonded_force = None
-        self._custom_coulomb_force = None
-        self._custom_lj_force = None
+        self._custom_nonbonded_force = None
 
         # Flag for whether the last move was a bulk sampling move.
         self._is_bulk = False
@@ -1160,8 +1159,7 @@ class GCMCSampler:
 
         # Clear the forces.
         self._nonbonded_force = None
-        self._custom_coulomb_force = None
-        self._custom_lj_force = None
+        self._custom_nonbonded_force = None
 
         # Clear the OpenMM context.
         self._openmm_context = None
@@ -2184,38 +2182,32 @@ class GCMCSampler:
                 map=_map,
             )
 
-            # Flags for the required force.
-            has_gng_coul = False
-            has_gng_lj = False
+            # Flag for the required force.
+            has_gng = False
 
             # Find the required forces.
             for force in d.context().getSystem().getForces():
-                if force.getName() == "GhostNonGhostCoulombForce":
-                    gng_coul_force = force
-                    has_gng_coul = True
-                elif force.getName() == "GhostNonGhostLJForce":
-                    gng_lj_force = force
-                    has_gng_lj = True
+                if force.getName() == "GhostNonGhostNonbondedForce":
+                    gng_force = force
+                    has_gng = True
+                    break
 
             # Make sure the force was found.
-            if not has_gng_coul:
+            if not has_gng:
                 raise ValueError(
-                    "Could not find the GhostNonGhostCoulombForce in the system"
-                )
-            if not has_gng_lj:
-                raise ValueError(
-                    "Could not find the GhostNonGhostLJForce in the system"
+                    "Could not find the GhostNonGhostNonbondedForce in the system"
                 )
 
-            # Get the parameters for the GhostNonGhost nonbonded forces.
+            # Get the parameters for the GhostNonGhostNonbondedForce.
             charges = _np.zeros(self._num_atoms, dtype=_np.float32)
             sigmas = _np.zeros(self._num_atoms, dtype=_np.float32)
             epsilons = _np.zeros(self._num_atoms, dtype=_np.float32)
             alphas = _np.zeros(self._num_atoms, dtype=_np.float32)
-            for i in range(gng_coul_force.getNumParticles()):
+            for i in range(gng_force.getNumParticles()):
                 # Custom force parameters are returned as floats.
-                q, alpha, _ = gng_coul_force.getParticleParameters(i)
-                half_sigma, two_sqrt_epsilon, _ = gng_lj_force.getParticleParameters(i)
+                q, half_sigma, two_sqrt_epsilon, alpha, _ = (
+                    gng_force.getParticleParameters(i)
+                )
                 # Charge in |e|, sigma in nm, epsilon in kJ/mol.
                 charges[i] = q
                 # Rescale and convert units.
@@ -2449,19 +2441,13 @@ class GCMCSampler:
             )
             # Update the custom NonBondedForce parameters.
             if self._is_fep:
-                self._custom_coulomb_force.setParticleParameters(
+                self._custom_nonbonded_force.setParticleParameters(
                     start_idx + i,
                     (
                         self._water_charge[i],
-                        0.0,
-                        0.0,
-                    ),
-                )
-                self._custom_lj_force.setParticleParameters(
-                    start_idx + i,
-                    (
                         self._water_sigma_custom[i],
                         self._water_epsilon_custom[i],
+                        0.0,
                         0.0,
                     ),
                 )
@@ -2474,8 +2460,7 @@ class GCMCSampler:
 
         # Update the CustomNonbondedForce parameters in the context.
         if self._is_fep:
-            self._custom_coulomb_force.updateParametersInContext(context)
-            self._custom_lj_force.updateParametersInContext(context)
+            self._custom_nonbonded_force.updateParametersInContext(context)
 
         # Update the state of the water on the GPU.
         self._kernels["update_water"](
@@ -2531,18 +2516,12 @@ class GCMCSampler:
             )
             # Update the CustomNonBondedForce parameters.
             if self._is_fep:
-                self._custom_coulomb_force.setParticleParameters(
+                self._custom_nonbonded_force.setParticleParameters(
                     start_idx + i,
                     (
                         0.0,
-                        0.0,
-                        0.0,
-                    ),
-                )
-                self._custom_lj_force.setParticleParameters(
-                    start_idx + i,
-                    (
                         self._water_sigma_custom[i],
+                        0.0,
                         0.0,
                         0.0,
                     ),
@@ -2553,8 +2532,7 @@ class GCMCSampler:
 
         # Update the CustomNonbondedForce parameters in the context.
         if self._is_fep:
-            self._custom_coulomb_force.updateParametersInContext(context)
-            self._custom_lj_force.updateParametersInContext(context)
+            self._custom_nonbonded_force.updateParametersInContext(context)
 
         # Update the state of the water on the GPU.
         self._kernels["update_water"](
@@ -2615,19 +2593,13 @@ class GCMCSampler:
             )
             # Update the CustomNonBondedForce parameters.
             if self._is_fep:
-                self._custom_coulomb_force.setParticleParameters(
+                self._custom_nonbonded_force.setParticleParameters(
                     start_idx + i,
                     (
                         self._water_charge[i],
-                        0.0,
-                        0.0,
-                    ),
-                )
-                self._custom_lj_force.setParticleParameters(
-                    start_idx + i,
-                    (
                         self._water_sigma_custom[i],
                         self._water_epsilon_custom[i],
+                        0.0,
                         0.0,
                     ),
                 )
@@ -2637,8 +2609,7 @@ class GCMCSampler:
 
         # Update the CustomNonbondedForce parameters in the context.
         if self._is_fep:
-            self._custom_coulomb_force.updateParametersInContext(context)
-            self._custom_lj_force.updateParametersInContext(context)
+            self._custom_nonbonded_force.updateParametersInContext(context)
 
         # Update the state of the water on the GPU.
         self._kernels["update_water"](
@@ -2705,8 +2676,7 @@ class GCMCSampler:
             # Assume the context has been recreated, so we need to get the
             # new forces.
             self._nonbonded_force = None
-            self._custom_coulomb_force = None
-            self._custom_lj_force = None
+            self._custom_nonbonded_force = None
             # Update even if the state is unchanged.
             force = True
 
@@ -2736,18 +2706,12 @@ class GCMCSampler:
                     )
                     # Update the CustomNonbondedForce parameters.
                     if self._is_fep:
-                        self._custom_coulomb_force.setParticleParameters(
+                        self._custom_nonbonded_force.setParticleParameters(
                             start_idx + i,
                             (
                                 0.0,
-                                0.0,
-                                0.0,
-                            ),
-                        )
-                        self._custom_lj_force.setParticleParameters(
-                            start_idx + i,
-                            (
                                 self._water_sigma_custom[i],
+                                0.0,
                                 0.0,
                                 0.0,
                             ),
@@ -2789,19 +2753,13 @@ class GCMCSampler:
                     )
                     # Update the CustomNonBondedForce parameters.
                     if self._is_fep:
-                        self._custom_coulomb_force.setParticleParameters(
+                        self._custom_nonbonded_force.setParticleParameters(
                             start_idx + i,
                             (
                                 self._water_charge[i],
-                                0.0,
-                                0.0,
-                            ),
-                        )
-                        self._custom_lj_force.setParticleParameters(
-                            start_idx + i,
-                            (
                                 self._water_sigma_custom[i],
                                 self._water_epsilon_custom[i],
+                                0.0,
                                 0.0,
                             ),
                         )
@@ -2838,8 +2796,7 @@ class GCMCSampler:
 
         # Update the CustomNonbondedForce parameters in the context.
         if self._is_fep:
-            self._custom_coulomb_force.updateParametersInContext(context)
-            self._custom_lj_force.updateParametersInContext(context)
+            self._custom_nonbonded_force.updateParametersInContext(context)
 
     def _set_nonbonded_forces(self, context):
         """
@@ -2852,15 +2809,13 @@ class GCMCSampler:
             The OpenMM context to use.
         """
         if self._nonbonded_force is None or (
-            self._is_fep and self._custom_coulomb_force is None
+            self._is_fep and self._custom_nonbonded_force is None
         ):
             for force in context.getSystem().getForces():
                 if isinstance(force, _openmm.NonbondedForce):
                     self._nonbonded_force = force
-                elif self._is_fep and force.getName() == "GhostNonGhostCoulombForce":
-                    self._custom_coulomb_force = force
-                elif self._is_fep and force.getName() == "GhostNonGhostLJForce":
-                    self._custom_lj_force = force
+                elif self._is_fep and force.getName() == "GhostNonGhostNonbondedForce":
+                    self._custom_nonbonded_force = force
                 elif "Barostat" in force.getName():
                     msg = (
                         f"GCMC must be used at constant volume: "
@@ -2874,9 +2829,7 @@ class GCMCSampler:
             _logger.error(msg)
             raise ValueError(msg)
 
-        if self._is_fep and (
-            self._custom_coulomb_force is None or self._custom_lj_force is None
-        ):
+        if self._is_fep and self._custom_nonbonded_force is None:
             msg = "Could not find a CustomNonbondedForce in the system"
             _logger.error(msg)
             raise ValueError(msg)

--- a/src/loch/_sampler.py
+++ b/src/loch/_sampler.py
@@ -545,6 +545,9 @@ class GCMCSampler:
             raise ValueError("'swap_end_states' must be of type 'bool'")
         self._swap_end_states = swap_end_states
 
+        if swap_end_states and self._lambda_schedule is not None:
+            self._lambda_schedule = self._lambda_schedule.reverse()
+
         # Check for waters and validate the template.
         try:
             self._water_template = system["water and not property is_perturbable"][0]

--- a/src/loch/_sampler.py
+++ b/src/loch/_sampler.py
@@ -79,11 +79,11 @@ class GCMCSampler:
         lambda_value: float = 0.0,
         rest2_scale: float = 1.0,
         rest2_selection: _Optional[str] = None,
-        coulomb_power: float = 0.0,
         shift_coulomb: str = "1 A",
         shift_delta: str = "1.5 A",
         softcore_form: str = "zacharias",
         taylor_power: int = 1,
+        beutler_alpha: float = 0.5,
         swap_end_states: bool = False,
         restart: bool = False,
         overwrite: bool = False,
@@ -212,14 +212,19 @@ class GCMCSampler:
 
         softcore_form : str
             The soft-core potential form to use for alchemical interactions.
-            This can be either 'zacharias' or 'taylor'. The default is
-            'zacharias'.
+            Valid options are 'zacharias' (default), 'taylor', and 'beutler'.
+            The Beutler form is recommended for ABFE calculations.
 
         taylor_power : int
             The power to use for the alpha term in the Taylor soft-core LJ
             expression, i.e. sig6 = sigma^6 / (alpha^m * sigma^6 + r^6).
             Must be between 0 and 4. The default is 1. Only used when
             softcore_form is 'taylor'.
+
+        beutler_alpha : float
+            The dimensionless scale factor for the r^6 shift in the Beutler
+            soft-core form. Must be >= 0. The default is 0.5. Only used when
+            softcore_form is 'beutler'.
 
         swap_end_states: bool
             Whether to swap the end states of the alchemical systems.
@@ -495,12 +500,6 @@ class GCMCSampler:
         self._rest2_selection = rest2_selection
 
         try:
-            coulomb_power = float(coulomb_power)
-        except Exception:
-            raise ValueError("'coulomb_power' must be of type 'float'")
-        self._coulomb_power = float(coulomb_power)
-
-        try:
             self._shift_coulomb = self._validate_sire_unit(
                 "shift_coulomb", shift_coulomb, _sr.u("A")
             )
@@ -533,6 +532,14 @@ class GCMCSampler:
         if not 0 <= taylor_power <= 4:
             raise ValueError("'taylor_power' must be between 0 and 4")
         self._taylor_power = taylor_power
+
+        try:
+            beutler_alpha = float(beutler_alpha)
+        except Exception:
+            raise ValueError("'beutler_alpha' must be of type 'float'")
+        if beutler_alpha < 0.0:
+            raise ValueError("'beutler_alpha' must be >= 0")
+        self._beutler_alpha = beutler_alpha
 
         if not isinstance(swap_end_states, bool):
             raise ValueError("'swap_end_states' must be of type 'bool'")
@@ -781,7 +788,6 @@ class GCMCSampler:
             f"restart={self._restart}, "
             f"rest2_scale={self._rest2_scale}, "
             f"rest2_selection={self._rest2_selection}, "
-            f"coulomb_power={self._coulomb_power}, "
             f"shift_coulomb={self._shift_coulomb}, "
             f"shift_delta={self._shift_delta}, "
             f"overwrite={self._overwrite}, "
@@ -1458,10 +1464,10 @@ class GCMCSampler:
                 self._rf_kappa,
                 self._rf_correction,
                 self._sc_softcore_form,
-                self._sc_coulomb_power,
                 self._sc_shift_coulomb,
                 self._sc_shift_delta,
                 self._sc_taylor_power,
+                self._sc_beutler_alpha,
                 block=(self._num_threads, 1, 1),
                 grid=(self._atom_blocks, self._batch_size, 1),
             )
@@ -2157,6 +2163,9 @@ class GCMCSampler:
             if self._softcore_form == _SoftcoreForm.TAYLOR:
                 _map["use_taylor_softening"] = True
                 _map["taylor_power"] = self._taylor_power
+            elif self._softcore_form == _SoftcoreForm.BEUTLER:
+                _map["use_beutler_softening"] = True
+                _map["beutler_alpha"] = self._beutler_alpha
 
             # Create a dynamics object.
             d = mols.dynamics(
@@ -2325,10 +2334,10 @@ class GCMCSampler:
 
         # Store soft-core parameters as scalars.
         self._sc_softcore_form = _np.int32(int(self._softcore_form))
-        self._sc_coulomb_power = _np.float32(self._coulomb_power)
         self._sc_shift_coulomb = _np.float32(self._shift_coulomb.value())
         self._sc_shift_delta = _np.float32(self._shift_delta.value())
         self._sc_taylor_power = _np.int32(self._taylor_power)
+        self._sc_beutler_alpha = _np.float32(self._beutler_alpha)
 
         # Store immutable per-atom buffers on GPU.
         self._gpu_sigma = sigmas

--- a/src/loch/_softcore.py
+++ b/src/loch/_softcore.py
@@ -29,3 +29,4 @@ class SoftcoreForm(IntEnum):
 
     ZACHARIAS = 0
     TAYLOR = 1
+    BEUTLER = 2

--- a/src/loch/_utils.py
+++ b/src/loch/_utils.py
@@ -36,6 +36,7 @@ def excess_chemical_potential(
     runtime: str = "5 ns",
     num_lambda: int = 24,
     replica_exchange: bool = False,
+    use_dispersion_correction: bool = False,
     work_dir: _Optional[str] = None,
 ) -> float:
     """
@@ -65,6 +66,9 @@ def excess_chemical_potential(
 
     replica_exchange: bool, optional
         Whether to use replica exchange during the calculation (default is False).
+
+    use_dispersion_correction: bool, optional
+        Whether to include the long-range dispersion correction (default is False).
 
     work_dir: str, optional
         Working directory for the decoupling simulation (default is None,
@@ -120,6 +124,9 @@ def excess_chemical_potential(
     if not isinstance(replica_exchange, bool):
         raise TypeError("'replica_exchange' must be a of type 'bool'.")
 
+    if not isinstance(use_dispersion_correction, bool):
+        raise TypeError("'use_dispersion_correction' must be a of type 'bool'.")
+
     if work_dir is not None:
         if not isinstance(work_dir, str):
             raise TypeError("'work_dir' must be a of type 'str'.")
@@ -154,7 +161,8 @@ def excess_chemical_potential(
             runtime=runtime,
             timestep="2 fs",
             h_mass_factor=1,
-            shift_delta="2.25 A",
+            soft_core_form="beutler",
+            use_dispersion_correction=use_dispersion_correction,
             output_directory=work_dir,
         )
     except Exception as e:
@@ -229,6 +237,7 @@ def standard_volume(
     cutoff: str = "10 A",
     num_samples: int = 5000,
     sample_interval: str = "1 ps",
+    use_dispersion_correction: bool = False,
 ) -> float:
     """
     Calculate the standard volume of water at the given temperature and pressure.
@@ -253,6 +262,9 @@ def standard_volume(
 
     sample_interval: str, optional
         Interval at which to sample the volume (default is "1 ps").
+
+    use_dispersion_correction: bool, optional
+        Whether to include the long-range dispersion correction (default is False).
 
     Returns
     -------
@@ -304,6 +316,9 @@ def standard_volume(
     if not u.has_same_units(sr.units.picosecond):
         raise ValueError("'sample_interval' has incorrect units.")
 
+    if not isinstance(use_dispersion_correction, bool):
+        raise TypeError("'use_dispersion_correction' must be a of type 'bool'.")
+
     # Disable the dynamics progress bar.
     sr.base.ProgressBar.set_silent()
 
@@ -319,7 +334,12 @@ def standard_volume(
 
     # Set up the NPT simulation.
     try:
-        d = system.dynamics(temperature=temperature, pressure=pressure, timestep="2 fs")
+        d = system.dynamics(
+            temperature=temperature,
+            pressure=pressure,
+            timestep="2 fs",
+            map={"use_dispersion_correction": use_dispersion_correction},
+        )
     except Exception as e:
         raise ValueError(f"Unable to set up NPT dynamics: {e}")
 

--- a/tests/test_energy.py
+++ b/tests/test_energy.py
@@ -20,6 +20,7 @@ from loch import GCMCSampler, SoftcoreForm
         ("bpti", "zacharias"),
         ("sd12", "zacharias"),
         ("sd12", "taylor"),
+        ("sd12", "beutler"),
     ],
 )
 def test_energy(fixture, softcore_form, platform, request):
@@ -56,6 +57,9 @@ def test_energy(fixture, softcore_form, platform, request):
     dyn_map = {}
     if sampler._softcore_form == SoftcoreForm.TAYLOR:
         dyn_map["use_taylor_softening"] = True
+    elif sampler._softcore_form == SoftcoreForm.BEUTLER:
+        dyn_map["use_beutler_softening"] = True
+        dyn_map["beutler_alpha"] = sampler._beutler_alpha
 
     # Create a dynamics object using the modified GCMC system.
     d = sampler.system().dynamics(
@@ -67,7 +71,6 @@ def test_energy(fixture, softcore_form, platform, request):
         timestep="2 fs",
         schedule=schedule,
         lambda_value=lambda_value,
-        coulomb_power=sampler._coulomb_power,
         shift_coulomb=str(sampler._shift_coulomb),
         shift_delta=str(sampler._shift_delta),
         platform=platform,
@@ -227,7 +230,6 @@ def test_platform_consistency(fixture, request):
         timestep="2 fs",
         schedule=schedule,
         lambda_value=lambda_value,
-        coulomb_power=cuda_sampler._coulomb_power,
         shift_coulomb=str(cuda_sampler._shift_coulomb),
         shift_delta=str(cuda_sampler._shift_delta),
         platform="cuda",
@@ -242,7 +244,6 @@ def test_platform_consistency(fixture, request):
         timestep="2 fs",
         schedule=schedule,
         lambda_value=lambda_value,
-        coulomb_power=opencl_sampler._coulomb_power,
         shift_coulomb=str(opencl_sampler._shift_coulomb),
         shift_delta=str(opencl_sampler._shift_delta),
         platform="opencl",
@@ -347,7 +348,6 @@ def test_energy_regression(fixture, platform, request):
         timestep="2 fs",
         schedule=schedule,
         lambda_value=lambda_value,
-        coulomb_power=sampler._coulomb_power,
         shift_coulomb=str(sampler._shift_coulomb),
         shift_delta=str(sampler._shift_delta),
         platform=platform,
@@ -414,7 +414,6 @@ def test_cached_kernel_correctness(platform, water_box):
             timestep="2 fs",
             schedule=schedule,
             lambda_value=0.5,
-            coulomb_power=sampler._coulomb_power,
             shift_coulomb=str(sampler._shift_coulomb),
             shift_delta=str(sampler._shift_delta),
             platform=platform,


### PR DESCRIPTION
This PR builds on top of https://github.com/OpenBioSim/sire/pull/440 by adding support for the long-range Lennard-Jones dispersion correction, Beutler soft-core for ABFE, and the reversal of lambda schedules using `LambdaSchedule.reverse()`.