### PR TITLE
fix water template for dry system

### DIFF
--- a/src/loch/_sampler.py
+++ b/src/loch/_sampler.py
@@ -558,7 +558,7 @@ class GCMCSampler:
                     "Please provide a water template."
                 )
             else:
-                if not isinstance(water_template, _sr.molecule.Molecule):
+                if not isinstance(water_template, _sr.mol.Molecule):
                     raise ValueError(
                         "'water_template' must be of type 'sire.mol.Molecule'"
                     )


### PR DESCRIPTION
when I use loch to simulate the water absorption into a dry system, which contains no water, the water_template provided causes Exception. it seems the type of the template should be _sr.mol.Molecule, rather than _sr.molecule.Molecule