### PR TITLE
Fix issue #32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ Changelog
 
 * Please add an item to this CHANGELOG for any new features or bug fixes when creating a PR.
 * Restrict PME energy calculation to required force groups [#29](https://github.com/OpenBioSim/loch/pull/29).
-* Add `set_lambda` and `_precompute_lambdas` so that a sampler can be re-used across lambda values without rebuilding an OpenMM context.
+* Add `set_lambda` and `_precompute_lambdas` so that a sampler can be re-used across lambda values without rebuilding an OpenMM context [#30](https://github.com/OpenBioSim/loch/pull/30).
+* Resolve unit conversions once when extracting the lambda dependent non-bonded parameters, rather than per atom, which dominated sampler setup [#33](https://github.com/OpenBioSim/loch/pull/33).
 
 [2026.1.0](https://github.com/openbiosim/loch/compare/2025.2.0...2026.1.0) - Jun 2026
 -------------------------------------------------------------------------------------

--- a/src/loch/_sampler.py
+++ b/src/loch/_sampler.py
@@ -2529,6 +2529,11 @@ class GCMCSampler:
 
         num_particles = gng_force.getNumParticles()
 
+        # Resolve the unit conversions once. Doing this per atom, by formatting
+        # and re-parsing a string, dominates the setup time for large systems.
+        nm_to_angstrom = _sr.u("1 nm").to("angstrom")
+        kj_per_mol_to_kcal_per_mol = _sr.u("1 kJ/mol").to("kcal/mol")
+
         for lambda_value, rest2_scale in wanted:
             d.set_lambda(lambda_value, rest2_scale=rest2_scale)
 
@@ -2545,10 +2550,8 @@ class GCMCSampler:
                 # Charge in |e|, sigma in nm, epsilon in kJ/mol.
                 charges[i] = q
                 # Rescale and convert units.
-                sigmas[i] = _sr.u(f"{2.0 * half_sigma} nm").to("angstrom")
-                epsilons[i] = _sr.u(f"{(0.5 * two_sqrt_epsilon) ** 2} kJ/mol").to(
-                    "kcal/mol"
-                )
+                sigmas[i] = 2.0 * half_sigma * nm_to_angstrom
+                epsilons[i] = (0.5 * two_sqrt_epsilon) ** 2 * kj_per_mol_to_kcal_per_mol
                 # Store the softening parameter.
                 alphas[i] = alpha
 


### PR DESCRIPTION
This PR closes #32 by avoiding a costly in-loop unit conversion when extracting per-atom lambda-dependent non-bonded parameters.